### PR TITLE
feat(quotes): mock /api/quotes and render table in UI

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,6 @@
 import Fastify from 'fastify';
 import cors from '@fastify/cors';
+import quotesRoute from './routes/quotes';
 
 async function main() {
   const app = Fastify({ logger: true });
@@ -9,6 +10,8 @@ async function main() {
 
   // api health check
   app.get('/api/health', async () => ({ status: 'ok', time: new Date().toISOString() }));
+  // register quotes route
+  await app.register(quotesRoute);
 
   try {
     await app.listen({ port: 8080, host: '0.0.0.0' });

--- a/server/src/routes/quotes.ts
+++ b/server/src/routes/quotes.ts
@@ -1,0 +1,39 @@
+import type { FastifyInstance } from 'fastify';
+
+export default async function quotesRoute(app: FastifyInstance) {
+  //  Querystring type tell Fastify/TS：
+  app.get<{ Querystring: { symbols?: string } }>(
+    '/api/quotes',
+    async (req, reply) => {
+      //  req.query has type：{ symbols?: string }
+      const { symbols } = req.query;
+
+      // validate
+      if (!symbols || symbols.trim() === '') {
+        reply.code(400);
+        return {
+          error:
+            'query param "symbols" is required, e.g. /api/quotes?symbols=AAPL,MSFT',
+        };
+      }
+
+      const list = Array.from(
+        new Set(
+          symbols
+            .split(',')
+            .map((s) => s.trim().toUpperCase())
+            .filter(Boolean)
+        )
+      );
+        // mock quotes data
+      const quotes = list.map((sym) => ({
+        symbol: sym,
+        price: Number((100 + Math.random() * 50).toFixed(2)),
+        change: Number((-2 + Math.random() * 4).toFixed(2)),
+        time: new Date().toISOString(),
+      }));
+
+      return { quotes };
+    }
+  );
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,27 +1,90 @@
 import { useEffect, useState } from 'react';
 
 type Health = { status: string; time: string };
+type Quote = { symbol: string; price: number; change: number; time: string };
 
 export default function App() {
   const [health, setHealth] = useState<Health | null>(null);
+  const [symbols, setSymbols] = useState('AAPL,MSFT');
+  const [quotes, setQuotes] = useState<Quote[]>([]);
+  const [loading, setLoading] = useState(false);
+
     useEffect(() => {
-    fetch('/api/health')               // /api Vite to 8080
+    fetch('/api/health')               // /api Vite to 8080/api/health
       .then(r => r.json())             // parse json response
       .then(setHealth)                 // set to state
       .catch(console.error);           // log error if any
   }, []);                              // run once on mount
 
+const fetchQuotes = async () => {
+    try {
+      setLoading(true);
+      const params = new URLSearchParams({ symbols });
+      const res = await fetch(`/api/quotes?${params.toString()}`); // 仍然走代理
+      const data = await res.json(); // { quotes: [...] }
+      setQuotes(data.quotes ?? []);
+    } catch (e) {
+      console.error(e);
+      setQuotes([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+
   return (
-    <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif' }}>
-      <h1>Stock Watcher (UI only)</h1>
-      <p>UI</p>
-      <p>
-        API: {
-          health
-            ? `${health.status} @ ${new Date(health.time).toLocaleTimeString()}`
-            : 'loading...'
-        }
-      </p>
+    <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif', maxWidth: 900, margin: '0 auto' }}>
+      <h1>Stock Watcher</h1>
+
+      <section style={{ marginBottom: 16 }}>
+        <p>API health: {health ? `${health.status} @ ${new Date(health.time).toLocaleTimeString()}` : 'loading...'}</p>
+      </section>
+
+      <section style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 12 }}>
+        <label htmlFor="symbols">Symbols (comma separated):</label>
+        <input
+          id="symbols"
+          value={symbols}
+          onChange={(e) => setSymbols(e.target.value)}
+          style={{ padding: 6, minWidth: 280 }}
+          placeholder="AAPL,MSFT,GOOG"
+        />
+        <button onClick={fetchQuotes} disabled={loading} style={{ padding: '6px 12px' }}>
+          {loading ? 'Loading...' : 'Fetch quotes'}
+        </button>
+      </section>
+
+      <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+        <thead>
+          <tr>
+            <th style={th}>Symbol</th>
+            <th style={th}>Price</th>
+            <th style={th}>Change</th>
+            <th style={th}>Time</th>
+          </tr>
+        </thead>
+        <tbody>
+          {quotes.map((q) => (
+            <tr key={q.symbol}>
+              <td style={td}>{q.symbol}</td>
+              <td style={td}>{q.price.toFixed(2)}</td>
+              <td style={{ ...td, color: q.change > 0 ? 'green' : q.change < 0 ? 'crimson' : 'inherit' }}>
+                {q.change >= 0 ? '+' : ''}
+                {q.change.toFixed(2)}
+              </td>
+              <td style={td}>{new Date(q.time).toLocaleTimeString()}</td>
+            </tr>
+          ))}
+          {!loading && quotes.length === 0 && (
+            <tr>
+              <td style={td} colSpan={4}>No data</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
     </div>
   );
 }
+
+const th: React.CSSProperties = { textAlign: 'left', borderBottom: '1px solid #ddd', padding: '8px 4px' };
+const td: React.CSSProperties = { borderBottom: '1px solid #f0f0f0', padding: '8px 4px' };


### PR DESCRIPTION
## What
- Backend (Fastify v4): add `GET /api/quotes?symbols=...` (mock), hand-rolled validation; register route.
- Frontend (Vite + React + TS): input + button + table; fetch via dev proxy `/api -> 127.0.0.1:8080`.

## Why
- Establish end-to-end quotes flow (5173 ↔ 8080) before plugging real data source.

## How
- server: `npm run dev` → test `http://127.0.0.1:8080/api/quotes?symbols=AAPL,MSFT`
- web: `npm run dev` → open `http://localhost:5173`, enter symbols, click "Fetch quotes".

## Test Plan
1) Start server & web.
2) Health shows `ok @ <time>`.
3) Input `AAPL,MSFT,GOOG` → table renders 3 rows with +/- colors.
4) Missing `symbols` → API returns 400 with error JSON.

## Notes
- `.gitignore` in place; no node_modules/dist tracked.
